### PR TITLE
test: add smoke coverage for decorator docs snippet#71

### DIFF
--- a/tests/test_docs_examples_verified.py
+++ b/tests/test_docs_examples_verified.py
@@ -15,6 +15,10 @@ async def _no_async_sleep(_: float) -> None:
     return None
 
 
+def _no_sleep(_: float) -> None:
+    return None
+
+
 def test_async_worker_retry_snippet_smoke(monkeypatch, capsys) -> None:
     monkeypatch.setattr(retry_helpers.asyncio, "sleep", _no_async_sleep)
     namespace = runpy.run_path(str(_snippet_path("async_worker_retry.py")))
@@ -44,3 +48,16 @@ def test_bench_retry_snippet_smoke() -> None:
 
     namespace["bench_success"](loop_count=3)
     namespace["bench_single_retry"](loop_count=3)
+
+
+def test_decorator_retry_snippet_smoke(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(retry_helpers.time, "sleep", _no_sleep)
+    monkeypatch.setattr(retry_helpers.asyncio, "sleep", _no_async_sleep)
+    namespace = runpy.run_path(str(_snippet_path("decorator_retry.py")))
+    monkeypatch.setattr(namespace["asyncio"], "sleep", _no_async_sleep)
+
+    namespace["main"]()
+
+    output = capsys.readouterr().out
+    assert "Sync: sync-ok" in output
+    assert "Async: async-ok" in output


### PR DESCRIPTION
## Summary
Adds smoke coverage for one more self-contained docs snippet in `tests/test_docs_examples_verified.py`.

## What changed
- added a smoke test for `docs/snippets/decorator_retry.py`
- stubbed sync and async sleep paths so the snippet runs quickly and locally
- asserted the expected `sync-ok` and `async-ok` output

## Why
This expands the set of visibly verified docs examples and improves confidence in the snippets.

## Verification
- `uv run pytest -o addopts="" tests/test_docs_examples_verified.py -k decorator_retry`
- full file also passes once the existing `pyperf` dev dependency is available for `bench_retry.py`
